### PR TITLE
fix some bugs

### DIFF
--- a/guides/editors.md
+++ b/guides/editors.md
@@ -1,0 +1,4 @@
+## vim / neovim
+
+When running in development with `webpack-dev-server`, you might notice that webpack doesn't always respond to changes when you hit save. This is because vim's default saving strategy sometimes writes directly to the original file, but other times renames the file and writes to a temporary one, which causes issues with watching changes. To fix this, add `set backupcopy=yes` in your `.vimrc` (see http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy')
+t

--- a/guides/editors.md
+++ b/guides/editors.md
@@ -1,4 +1,3 @@
 ## vim / neovim
 
-When running in development with `webpack-dev-server`, you might notice that webpack doesn't always respond to changes when you hit save. This is because vim's default saving strategy sometimes writes directly to the original file, but other times renames the file and writes to a temporary one, which causes issues with watching changes. To fix this, add `set backupcopy=yes` in your `.vimrc` (see http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy')
-t
+When running in development with `webpack-dev-server`, you might notice that webpack doesn't always respond to changes when you hit save. This is because vim's default saving strategy sometimes writes directly to the original file, but other times renames the file and writes to a temporary one, which causes issues with watching changes. To fix this, add `set backupcopy=yes` in your `.vimrc`.

--- a/guides/editors.md
+++ b/guides/editors.md
@@ -1,3 +1,3 @@
 ## vim / neovim
 
-When running in development with `webpack-dev-server`, you might notice that webpack doesn't always respond to changes when you hit save. This is because vim's default saving strategy sometimes writes directly to the original file, but other times renames the file and writes to a temporary one, which causes issues with watching changes. To fix this, add `set backupcopy=yes` in your `.vimrc`.
+When running in development with `webpack-dev-server`, you might notice that webpack doesn't always respond to changes when you hit save. This is because vim's default saving strategy sometimes writes directly to the original file, but other times renames the file and writes to a temporary one, which causes issues with watching changes. To fix this, add `set backupcopy=yes` in your config file. (See https://github.com/webpack/webpack/issues/781 for more info)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bs-react-test-renderer": "^1.0.0",
     "html-webpack-plugin": "^2.28.0",
     "jest": "^20.0.4",
+    "npm-run-all": "^4.0.2",
     "pushstate-server": "^3.0.0",
     "rimraf": "^2.6.1",
     "webpack": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -5,16 +5,17 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "now-start": "pushstate-server public/",
     "build": "npm-run-all build:*",
     "build:bsb": "bsb -make-world",
     "build:webpack": "webpack -p",
     "clean": "npm-run-all clean:*",
     "clean:bsb": "bsb -clean-world",
     "clean:project": "rimraf public/main.js lib .merlin 'src/**/*.js'",
-    "dev": "npm-run-all --parallel dev:*",
+    "dev": "npm run build:bsb && npm run dev:parallel",
+    "dev:parallel": "npm-run-all --parallel dev:bsb dev:webpack",
     "dev:bsb": "npm run build:bsb -- -w",
     "dev:webpack": "webpack-dev-server -w",
+    "now-start": "pushstate-server public/",
     "jest": "jest",
     "test": "npm-run-all build:bsb jest"
   },
@@ -39,11 +40,11 @@
     "bs-react-test-renderer": "^1.0.0",
     "html-webpack-plugin": "^2.28.0",
     "jest": "^20.0.4",
-    "npm-run-all": "^4.0.2",
     "pushstate-server": "^3.0.0",
     "rimraf": "^2.6.1",
     "webpack": "^2.6.1",
-    "webpack-dev-server": "2"
+    "webpack-dev-server": "2",
+    "write-file-webpack-plugin": "^4.0.2"
   },
   "jest": {
     "roots": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const WriteFilePlugin = require('write-file-webpack-plugin');
 
 module.exports = {
   entry: './lib/js/src/index',
@@ -10,5 +11,6 @@ module.exports = {
   },
   devServer: {
     contentBase: path.resolve(__dirname, 'public')
-  }
+  },
+  plugins: [ new WriteFilePlugin() ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,7 +860,7 @@ debug@2.6.1, debug@^2.2.0:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.4, debug@^2.1.1, debug@^2.6.3:
+debug@^2.1.1, debug@^2.6.3:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
   dependencies:
@@ -1277,6 +1277,10 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
+filesize@^3.2.1:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -1287,23 +1291,11 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-finalhandler@1.0.0:
+finalhandler@1.0.0, finalhandler@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.0.tgz#b5691c2c0912092f18ac23e9416bde5cd7dc6755"
   dependencies:
     debug "2.6.1"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    on-finished "~2.3.0"
-    parseurl "~1.3.1"
-    statuses "~1.3.1"
-    unpipe "~1.0.0"
-
-finalhandler@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.2.tgz#d0e36f9dbc557f2de14423df6261889e9d60c93a"
-  dependencies:
-    debug "2.6.4"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
@@ -2483,7 +2475,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0:
+lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2615,6 +2607,10 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.11.2:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 ms@0.7.1:
   version "0.7.1"
@@ -4121,6 +4117,16 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-webpack-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-webpack-plugin/-/write-file-webpack-plugin-4.0.2.tgz#70c89a4d99a105e1aed778b21b5f75e7af4da58b"
+  dependencies:
+    chalk "^1.1.1"
+    filesize "^3.2.1"
+    lodash "^4.5.1"
+    mkdirp "^0.5.1"
+    moment "^2.11.2"
 
 xml-char-classes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This addresses https://github.com/knowbody/crra/issues/5

If you go into `public/index.html`, you can see the bundled JS file is `main.js`. When running `webpack` normally, this generates the bundled output correctly.

However, when running `npm run dev`, you're using `webpack-dev-server`, which keeps the file in memory (not actually written to disk). To fix this, I'm using a plugin for `webpack-dev-server` called `write-file-webpack-plugin` which will correctly write `main.js` to the `public` folder (NOTE: this does not affect the normal `webpack` process).

Also, I had a slight bug when I changed the `package.json`. Launching `bsb` & `webpack` at the same time in watch mode created a race condition, because webpack needed the the files that were compiled by `bsb`. To fix this, I first run `build:bsb`, and *then* start `bsb` and `webpack` in watch mode.

Additionally, I've also added a note for vim users who don't always see webpack HMR changes