### PR TITLE
make changes to cli

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,6 +1,5 @@
-#!/usr/bin/env node
-
 require('shelljs/global');
+
 const path = require('path');
 const fs = require('fs');
 const figlet = require('figlet');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,20 +1,15 @@
 #!/usr/bin/env node
 
-const program = require('commander')
-const spawn = require('child_process').spawn;
-const package = require('../package.json');
-const chalk = require('chalk');
+const program = require('commander');
 
 const build = require('./build');
+const pkg = require('../package.json');
 
 program
-.version(package.version)
-  .usage('<keywords>')
-  .option('-n, --new, [name]', 'Create the application')
-  .parse(process.argv);
+  .version(pkg.version);
 
-if (program.args.length === 1) {
-  spawn(build(program.args[0]), { shell: true, stdio: 'inherit' });
-} else if (program.args.length < 1) {
-  console.log(chalk.red('Please supply a name for your new Reason React app.'));
-}
+program
+  .command('new [name]', { isDefault: true })
+  .action(name => build(name));
+
+program.parse(process.argv);


### PR DESCRIPTION
This addresses https://github.com/knowbody/crra/issues/16

node 8's child_process is stricter about how arguments are passed in ([see here](https://github.com/nodejs/node/blob/faf6654ff75e0f275afddfd980387235c3ddf103/lib/child_process.js#L360)). That said, I don't think `bin/build.js` has to be an executable/be spawned

Creating a new app is the same command (`create-reason-react-app myApp`), so it should still work with `yarn create`. The CLI now defaults to creating a `new` app, so we can add some other commands in here, like maybe deploy, etc.