### PR TITLE
Added `start` commands in generate project to mirror Create React App

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -15,6 +15,10 @@
     "dev:parallel": "npm-run-all --parallel dev:bsb dev:webpack",
     "dev:bsb": "npm run build:bsb -- -w",
     "dev:webpack": "webpack-dev-server -w",
+    "start": "npm run build:bsb && npm run start:parallel",
+    "start:parallel": "npm-run-all --parallel start:bsb start:webpack",
+    "start:bsb": "npm run build:bsb -- -w",
+    "start:webpack": "webpack-start-server -w",
     "now-start": "pushstate-server public/",
     "jest": "jest",
     "test": "npm-run-all build:bsb jest"


### PR DESCRIPTION
Hi! First off, thanks for working on this project. I've been noodling around in Reason and React, and this has been invaluable.

Second, this PR addresses a small issue I've run into—create Create React App uses `yarn start` or `npm run start`, while Create Reason React App uses `yarn dev` or `npm run start`. I've found myself jumping between the two frequently, so the different defaults between the two has been discombobulating.

This PR resolves my problem by allowing users to use both styles. 😬 