### PR TITLE
Migrate basic example to webpack bs-loader

### DIFF
--- a/templates/basic/bsconfig.json
+++ b/templates/basic/bsconfig.json
@@ -15,9 +15,6 @@
     "bs-jest",
     "bs-react-test-renderer"
   ],
-  "js-post-build": {
-    "cmd": "./scripts/copy.js"
-  },
   "sources": [
     {
       "dir": "src",

--- a/templates/basic/package-lock.json
+++ b/templates/basic/package-lock.json
@@ -364,8 +364,7 @@
     "big.js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-      "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
-      "dev": true
+      "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -495,6 +494,18 @@
               "dev": true
             }
           }
+        }
+      }
+    },
+    "bs-loader": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/bs-loader/-/bs-loader-1.5.3.tgz",
+      "integrity": "sha512-9OLf8qizSplEegCkKSFxHhf6RToRm9NbPYa+RMRtdEHZoBaHW2dgJU2jlosR4jNoxJ6NkMv9U1QJnoYFhw+rwg==",
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0="
         }
       }
     },
@@ -1097,8 +1108,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -3139,8 +3149,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4059,7 +4068,9 @@
       "dev": true
     },
     "reason-react": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/reason-react/-/reason-react-0.1.5.tgz",
+      "integrity": "sha1-Lq4QiTb/fXtsIUi/BwAPGMdbKTQ="
     },
     "redent": {
       "version": "1.0.0",

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -10,9 +10,8 @@
     "build:webpack": "webpack -p",
     "clean": "npm-run-all clean:*",
     "clean:bsb": "bsb -clean-world",
-    "clean:project": "rimraf public/main.js lib .merlin 'src/**/*.js'",
-    "start": "node scripts/startDev.js",
-    "start:parallel": "npm-run-all --parallel start:bsb start:webpack",
+    "clean:project": "rimraf public/main.js lib .merlin",
+    "start": "npm run start:webpack",
     "start:bsb": "npm run build:bsb -- -w",
     "start:webpack": "node scripts/webpackDevServer.js",
     "jest": "jest",
@@ -29,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "bs-director": "^0.0.1",
+    "bs-loader": "^1.5.3",
     "figlet": "^1.2.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
@@ -50,7 +50,7 @@
   },
   "jest": {
     "roots": [
-      "src"
+      "lib/js/src"
     ]
   }
 }

--- a/templates/basic/webpack.config.js
+++ b/templates/basic/webpack.config.js
@@ -6,18 +6,31 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:8080',
     'webpack/hot/only-dev-server',
-    './lib/js/src/index.js',
+    './src/index',
   ],
   output: {
     filename: '[name].js',
     path: path.join(__dirname, './public'),
     publicPath: '/public'
   },
+  devServer: {
+    contentBase: path.resolve(__dirname, 'public')
+  },
+  module: {
+    rules: [
+      { test: /\.(re|ml)$/, use: 'bs-loader' },
+    ]
+  },
+  resolve: {
+    extensions: ['.re', '.js']
+  },
   plugins: [
-    new WriteFilePlugin({
-      log: false,
-      test: /main\.js/,
-    }),
-    new webpack.HotModuleReplacementPlugin(),
+    // TODO: Not familiar with how Hot Replacement works, but it's not working with bs-loader
+    
+    // new WriteFilePlugin({
+    //   log: false,
+    //   test: /main\.js/,
+    // }),
+    // new webpack.HotModuleReplacementPlugin(),
   ]
 };


### PR DESCRIPTION
Re: #40 

Don't merge this yet--it's not complete. This is just the basic changes necessary so we can review first.

TODO:
- [ ] Copy previous `basic` template back in as `pretty-error-display`
- [ ] Either figure out how to make HMR work, or replace it with live reload
- [ ] Migrate interop example as well

As discussed, bs-loader doesn't have great error output for ReasonML errors. I'm actually going to try to fix that right now, but we'll see..